### PR TITLE
TFW: add check for apache license on built JARs

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -24,3 +24,22 @@ jobs:
       run: chmod +x gradlew
     - name: Build with Gradle
       run: ./gradlew build
+    - name: Check JAR licenses
+      run: |
+        JARS=$(find ./ -name '*.jar' -type f | grep yoko | grep libs)
+        SHIPPED_JARS=("osgi" "util" "spec-corba" "rmi-spec" "rmi-impl" "core" "jdk-supplement" "testify")
+        for shippedJar in ${SHIPPED_JARS[@]}; do
+            for jar in $JARS; do
+                if [[ $(basename $jar) == *"$shippedJar"* ]]; then
+                    echo "Checking $(basename $jar)"
+                    if $(unzip -p $jar META-INF/MANIFEST.MF | grep -q "Bundle-License: https://www.apache.org/licenses/LICENSE-2.0.txt"); then
+                        echo "License found"
+                    else
+                        echo "License not found"
+                        exit 1
+                    fi
+                else
+                    continue
+                fi
+            done
+        done

--- a/yoko-testify/build.gradle
+++ b/yoko-testify/build.gradle
@@ -6,7 +6,10 @@ dependencies {
 
 jar {
   manifest {
-    instruction 'Bundle-Description' , 'Apache Yoko Implementation Utilities'
+    instruction 'Bundle-Description' , 'Testify ORB Test Framework'
     instruction 'Export-Package'     , '*'
+    instruction 'Bundle-symbolicName', 'testify'
+    instruction 'Bundle-DocURL'      , 'https://github.com/OpenLiberty/yoko/wiki'
+    instruction 'Bundle-Vendor'      , 'OpenLiberty'
   }
 }


### PR DESCRIPTION
Closes https://github.com/OpenLiberty/yoko/issues/164
- Contains changes to `yoko-testify-*.jar` manifest
- Checks for the APACHE 2.0 license on all JARs built by Gradle